### PR TITLE
Enhancement: Properties to have icons and padding to the icons around the chip text

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -42,6 +42,21 @@
         app:chipIcon="@drawable/ic_palette" />
 
     <com.jahirfiquitiva.chip.ChipView
+        android:id="@+id/icon_chip_text_icon"
+        android:layout_margin="6dp"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:chipRadius="8dp"
+        app:chipBgColor="#345"
+        app:chipTextColor="#fff"
+        app:chipText="I am Chip with drawable and padding"
+        app:chipTextIconPadding="10dp"
+        app:chipTextIconRight="@drawable/ic_palette"
+        app:chipTextIconTop="@drawable/ic_palette"
+        app:chipTextIconLeft="@drawable/ic_palette"
+        app:chipTextIconBottom="@drawable/ic_palette" />
+
+    <com.jahirfiquitiva.chip.ChipView
         android:id="@+id/action_chip"
         android:layout_margin="6dp"
         android:layout_width="wrap_content"

--- a/library/src/main/kotlin/com/jahirfiquitiva/chip/ChipView.kt
+++ b/library/src/main/kotlin/com/jahirfiquitiva/chip/ChipView.kt
@@ -143,6 +143,13 @@ open class ChipView @JvmOverloads constructor(
             rippleColor = styles.getColor(R.styleable.ChipView_chipRippleColor, 0)
             
             setIcon(styles.getDrawable(R.styleable.ChipView_chipIcon))
+            setImageToText(
+                styles.getDrawable(R.styleable.ChipView_chipTextIconLeft),
+                styles.getDrawable(R.styleable.ChipView_chipTextIconTop),
+                styles.getDrawable(R.styleable.ChipView_chipTextIconBottom),
+                styles.getDrawable(R.styleable.ChipView_chipTextIconRight)
+                )
+            setPaddingForImageAndText(styles.getDimension(R.styleable.ChipView_chipTextIconPadding, 0F).roundToInt())
             setActionIcon(styles.getDrawable(R.styleable.ChipView_chipActionIcon))
             
             super.setRadius(0F)
@@ -276,6 +283,16 @@ open class ChipView @JvmOverloads constructor(
     @CallSuper
     open fun setActionIcon(actionIcon: Icon?) {
         actionIconView?.setImageIcon(actionIcon)
+    }
+    
+    @CallSuper
+    open fun setImageToText(leftDrawable: Drawable?, topDrawable: Drawable?, bottomDrawable: Drawable?, rightDrawable: Drawable?) {
+        textView?.setCompoundDrawablesWithIntrinsicBounds(leftDrawable, topDrawable, bottomDrawable, rightDrawable)
+    }
+
+    @CallSuper
+    open fun setPaddingForImageAndText(textDrawablePadding: Int) {
+        textView?.compoundDrawablePadding = textDrawablePadding
     }
     
     @ColorInt

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -23,6 +23,11 @@
         <attr name="chipTextSize" format="dimension|reference" />
         <attr name="chipRadius" format="dimension|reference" />
         <attr name="chipIcon" format="reference" />
+        <attr name="chipTextIconLeft" format="reference" />
+        <attr name="chipTextIconRight" format="reference" />
+        <attr name="chipTextIconTop" format="reference" />
+        <attr name="chipTextIconBottom" format="reference" />
+        <attr name="chipTextIconPadding" format="dimension|reference" />
         <attr name="chipActionIcon" format="reference" />
         <attr name="chipStrokeWidth" format="dimension|reference" />
         <attr name="chipStrokeColor" format="color|reference" />


### PR DESCRIPTION
<!--
Any HTML comment will be stripped when the markdown is rendered, so you don't need to delete them.
-->

### Description
Added extra properties to have icons and padding to the icons at the top, bottom, left, and right of the text.

### Motivation
This provides the flexibility to customize the ChipView. Users can have a drawable icon not just at the start or the end of the view, it can be at any of the four directions with customizable padding.

![Chip](https://user-images.githubusercontent.com/20037228/197754499-0a9f5889-5f76-471b-b0f5-015fb55a17e3.png)

Please let me know if you have any feedback.
Thank you!